### PR TITLE
Test fixes

### DIFF
--- a/zarf.yaml
+++ b/zarf.yaml
@@ -98,7 +98,7 @@ components:
 
   - name: keycloak
     description: "Git repositories and OCI images used by Keycloak"
-    required: false
+    required: true
     repos:
       - https://repo1.dso.mil/platform-one/big-bang/apps/security-tools/keycloak.git@18.2.1-bb.4
       - https://repo1.dso.mil/platform-one/big-bang/apps/core/authservice.git@0.5.2-bb.0
@@ -129,7 +129,7 @@ components:
 
   - name: big-bang-storage
     description: "Git repositories and OCI images need for Big Bang storage"
-    required: false
+    required: true
     repos:
       - https://repo1.dso.mil/platform-one/big-bang/apps/application-utilities/minio-operator.git@4.4.28-bb.2
       - https://repo1.dso.mil/platform-one/big-bang/apps/application-utilities/minio.git@4.4.28-bb.1

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -131,8 +131,8 @@ components:
     description: "Git repositories and OCI images need for Big Bang storage"
     required: true
     repos:
-      - https://repo1.dso.mil/platform-one/big-bang/apps/application-utilities/minio-operator.git@4.4.28-bb.2
-      - https://repo1.dso.mil/platform-one/big-bang/apps/application-utilities/minio.git@4.4.28-bb.1
+      - https://repo1.dso.mil/platform-one/big-bang/apps/application-utilities/minio-operator.git@4.5.1-bb.0
+      - https://repo1.dso.mil/platform-one/big-bang/apps/application-utilities/minio.git@4.5.1-bb.0
     images:
       - "registry1.dso.mil/ironbank/opensource/minio/operator:v4.5.1"
       - "registry1.dso.mil/ironbank/opensource/minio/console:v0.20.4"


### PR DESCRIPTION
Set keycloak and big-bang-storage (minio-operator/minio) to required: true since those packages are enabled in the values.yaml and will get deployed as part of a zark package deploy with the --confirm option.

Updated the minio-operator/minio repo tags to match what was expected by the corresponding flux gitrepos. 