### PR TITLE
Fix iac ref

### DIFF
--- a/.github/workflows/pipeline.aws.yaml
+++ b/.github/workflows/pipeline.aws.yaml
@@ -30,7 +30,7 @@ jobs:
           download-init-package: true
 
       - name: Login to Registry1
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: registry1.dso.mil
           username: ${{ secrets.REGISTRY1_USERNAME }}

--- a/aws/loki/main.tf
+++ b/aws/loki/main.tf
@@ -6,7 +6,7 @@ provider "aws" {
 
 
 module "S3" {
-    source = "github.com/defenseunicorns/iac//modules/s3-irsa?ref=s3-force-delete-option"
+    source = "github.com/defenseunicorns/delivery-aws-iac//modules/s3-irsa"
     name_prefix = "${var.name}"
     eks_oidc_provider_arn = "${var.eks_oidc_provider_arn}"
     kubernetes_service_account = "logging-loki"


### PR DESCRIPTION
[PR was merged](https://github.com/defenseunicorns/delivery-aws-iac/pull/194) so this needs to point back to `main` (since the `s3-force-delete-option` branch no longer exists) so that CI can work again.