### PR TITLE
fix: bump refs to support k8s v1.26

### DIFF
--- a/.github/workflows/eks/config.yaml
+++ b/.github/workflows/eks/config.yaml
@@ -4,7 +4,7 @@ kind: ClusterConfig
 metadata:
   name: ###ZARF_VAR_CLUSTER_NAME###
   region: us-west-2
-  version: "1.23"
+  version: "1.26"
 
 # May want to look at this for testing 
 # privateCluster:

--- a/.github/workflows/eks/config.yaml
+++ b/.github/workflows/eks/config.yaml
@@ -15,7 +15,8 @@ iam:
 
 addons:
   - name: aws-ebs-csi-driver
-    version: v1.5.2-eksbuild.1
+    version: v1.17.0-eksbuild.1
+
     attachPolicyARNs:
       - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
 

--- a/.github/workflows/eks/zarf-config.yaml
+++ b/.github/workflows/eks/zarf-config.yaml
@@ -3,7 +3,7 @@ package:
     max_package_size: "1000000000"
     set:
       bigbang_version: "1.56.0"
-      eksctl_version: v0.135.0
+      eksctl_version: v0.138.0
   deploy:
     set: 
       cluster_name: bigbang-aws-install

--- a/defense-unicorns-distro/scripts/preflight.sh
+++ b/defense-unicorns-distro/scripts/preflight.sh
@@ -12,7 +12,7 @@ server_minor_version=$(echo "$server_version" | cut -d"." -f2)
 
 # Define a supported version
 supported_major_version="v1"
-supported_minor_version="23"
+supported_minor_version="26"
 
 echo "Server Major: ${server_major_version}"
 echo "Server Minor: ${server_minor_version}"

--- a/values/neuvector.yaml
+++ b/values/neuvector.yaml
@@ -2,7 +2,7 @@ neuvector:
   enabled: true
   values:
     containerd:
-      enabled: false
+      enabled: true
     monitor:
       install: true # getting error here on having this come up
 


### PR DESCRIPTION
Bumping k8s version in advance of BB 2.0 per [this note](https://repo1.dso.mil/big-bang/bigbang/-/releases/2.0.0#user-content-release-notes-200:~:text=Please%20see%20our%20documentation%20page%20for%20more%20information%20on%20how%20to%20consume%20and%20deploy%20BigBang.%20This%20release%20was%20primarily%20tested%20on%20Kubernetes%201.26.3).