### PR TITLE
Enable hosts using the public ingress gateway to accessible

### DIFF
--- a/values/istio.yaml
+++ b/values/istio.yaml
@@ -26,6 +26,9 @@ istio:
               memory: "1Gi"
   gateways:
     public:
+      ingressGateway: public-ingressgateway
+      hosts:
+        - "*.{{ .Values.domain }}"
       tls:
         key: "###ZARF_VAR_PUBLIC_KEY###"
         cert: "###ZARF_VAR_PUBLIC_CERT###"


### PR DESCRIPTION
Allow services to access the public ingress gateway by default.