### PR TITLE
enable metrics server again

### DIFF
--- a/values/values.yaml
+++ b/values/values.yaml
@@ -19,8 +19,5 @@ twistlock:
   enabled: false
 
 addons:
-  metricsServer:
-    enabled: false
-
   velero:
     enabled: false


### PR DESCRIPTION
This is hard turned off instead of turning on when the kubernetes environment doesn't have it