### PR TITLE
Pushing --confirm to the end of zarf argument lists

### DIFF
--- a/.github/workflows/pipeline.aws.yaml
+++ b/.github/workflows/pipeline.aws.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Create EKS cluster and Zarf Init
         run: |
           echo ${{ steps.get_cluster_name.outputs.eks_cluster_name }}
-          zarf package deploy zarf-package-distro-eks-multi.tar.zst --confirm --set cluster_name=${{ steps.get_cluster_name.outputs.eks_cluster_name }}
+          zarf package deploy zarf-package-distro-eks-multi.tar.zst --set cluster_name=${{ steps.get_cluster_name.outputs.eks_cluster_name }} --confirm 
         working-directory: .github/workflows/eks #just holds the zarf-config
         id: create-cluster
          
@@ -86,7 +86,7 @@ jobs:
       - name: Deploy DUBBD-AWS
         run: |
           echo ${{ steps.get_cluster_name.outputs.eks_cluster_name }}
-          zarf package deploy zarf-package-*.tar.zst --confirm --set loki_force_destroy=true --set loki_kms_key_arn=${{ steps.get.outputs.kms_key_arn }} --set name=${{ steps.get_cluster_name.outputs.eks_cluster_name }}
+          zarf package deploy zarf-package-*.tar.zst --set loki_force_destroy=true --set loki_kms_key_arn=${{ steps.get.outputs.kms_key_arn }} --set name=${{ steps.get_cluster_name.outputs.eks_cluster_name }} --confirm 
 
         working-directory: aws
         timeout-minutes: 60

--- a/.github/workflows/pipeline.dubbd.yaml
+++ b/.github/workflows/pipeline.dubbd.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Create EKS cluster
         run: |
           echo ${{ steps.get_cluster_name.outputs.short_sha }}
-          zarf package deploy zarf-package-distro-eks-multi.tar.zst --confirm --set cluster_name=${{ steps.get_cluster_name.outputs.short_sha }}
+          zarf package deploy zarf-package-distro-eks-multi.tar.zst --set cluster_name=${{ steps.get_cluster_name.outputs.short_sha }} --confirm 
         working-directory: .github/workflows/eks
         # eventually have zarf deploy   \
       - name: Show Cluster
@@ -65,7 +65,7 @@ jobs:
         timeout-minutes: 60
       
       - name: Deploy DUBBD
-        run: zarf package deploy zarf-package-*.tar.zst --confirm -l debug
+        run: zarf package deploy zarf-package-*.tar.zst --confirm
         working-directory: defense-unicorns-distro
         timeout-minutes: 60
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 ~/
 .DS_Store
 defense-unicorns-distro/preflight.sh
+.terraform

--- a/aws/loki/README.md
+++ b/aws/loki/README.md
@@ -1,0 +1,50 @@
+# Loki 
+
+Terraform for deploying resources necessary for Loki
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_S3"></a> [S3](#module\_S3) | github.com/defenseunicorns/delivery-aws-iac//modules/s3-irsa | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_eks_cluster.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Option to set force destroy | `bool` | `false` | no |
+| <a name="input_key_alias"></a> [key\_alias](#input\_key\_alias) | alias for KMS Key | `string` | `"bigbang-loki"` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | n/a | `any` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name for cluster | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_region"></a> [aws\_region](#output\_aws\_region) | n/a |
+| <a name="output_dynamodb_name"></a> [dynamodb\_name](#output\_dynamodb\_name) | n/a |
+| <a name="output_eks_cluster_oidc_arn"></a> [eks\_cluster\_oidc\_arn](#output\_eks\_cluster\_oidc\_arn) | The ARN of the OIDC Provider of the EKS Cluster |
+| <a name="output_irsa_role"></a> [irsa\_role](#output\_irsa\_role) | n/a |
+| <a name="output_s3"></a> [s3](#output\_s3) | n/a |
+| <a name="output_s3_bucket"></a> [s3\_bucket](#output\_s3\_bucket) | n/a |
+<!-- END_TF_DOCS -->

--- a/aws/loki/main.tf
+++ b/aws/loki/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 module "S3" {
-  source                     = "github.com/defenseunicorns/delivery-aws-iac//modules/s3-irsa"
+  source                     = "github.com/defenseunicorns/delivery-aws-iac//modules/s3-irsa?ref=v0.0.4-alpha"
   name_prefix                = var.name
   eks_oidc_provider_arn      = local.oidc_arn
   kubernetes_service_account = "logging-loki"

--- a/aws/loki/main.tf
+++ b/aws/loki/main.tf
@@ -11,64 +11,21 @@ data "aws_caller_identity" "current" {}
 
 data "aws_partition" "current" {}
 
+data "aws_region" "current" {}
+
 locals {
   oidc_url_without_protocol = substr(data.aws_eks_cluster.existing.identity[0].oidc[0].issuer, 8, -1) # removes "https://"
   oidc_arn                  = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc_url_without_protocol}"
 }
 
 module "S3" {
-    source = "github.com/defenseunicorns/delivery-aws-iac//modules/s3-irsa"
-    name_prefix = "${var.name}"
-    eks_oidc_provider_arn = local.oidc_arn
-    kubernetes_service_account = "logging-loki"
-    kubernetes_namespace = "logging"
-    dynamodb_enabled = "false"
-    kms_key_arn = "${var.kms_key_arn}"
-    force_destroy = "${var.force_destroy}"
+  source                     = "github.com/defenseunicorns/delivery-aws-iac//modules/s3-irsa"
+  name_prefix                = var.name
+  eks_oidc_provider_arn      = local.oidc_arn
+  kubernetes_service_account = "logging-loki"
+  kubernetes_namespace       = "logging"
+  dynamodb_enabled           = "false"
+  kms_key_arn                = var.kms_key_arn
+  force_destroy              = var.force_destroy
 }
 
-data "aws_region" "current" {}
-
-output "aws_region" {
-  value = data.aws_region.current.name
-}
-
-output "irsa_role" {
-  value = module.S3.irsa_role
-}
-
-output "s3" {
-  value = module.S3
-}
-
-output "s3_bucket" {
-  value =  module.S3.s3_bucket
-}
-
-output "dynamodb_name" {
-  value =  module.S3.dynamodb_name
-}
-
-output "eks_cluster_oidc_arn" {
-  description = "The ARN of the OIDC Provider of the EKS Cluster"
-  value       = local.oidc_arn
-}
-
-variable "name" {
-    description = "Name for cluster"
-}
-
-variable "kms_key_arn" {
-
-}
-
-variable "key_alias" {
-  description = "alias for KMS Key"
-  default = "bigbang-loki"
-}
-
-variable "force_destroy" {
-  description = "Option to set force destroy"
-  type        = bool
-  default     = false
-}

--- a/aws/loki/output.tf
+++ b/aws/loki/output.tf
@@ -1,0 +1,25 @@
+
+output "aws_region" {
+  value = data.aws_region.current.name
+}
+
+output "irsa_role" {
+  value = module.S3.irsa_role
+}
+
+output "s3" {
+  value = module.S3
+}
+
+output "s3_bucket" {
+  value = module.S3.s3_bucket
+}
+
+output "dynamodb_name" {
+  value = module.S3.dynamodb_name
+}
+
+output "eks_cluster_oidc_arn" {
+  description = "The ARN of the OIDC Provider of the EKS Cluster"
+  value       = local.oidc_arn
+}

--- a/aws/loki/terraform.tfvars
+++ b/aws/loki/terraform.tfvars
@@ -1,3 +1,3 @@
-name = "###ZARF_VAR_NAME###"
-kms_key_arn = "###ZARF_VAR_LOKI_KMS_KEY_ARN###"
+name          = "###ZARF_VAR_NAME###"
+kms_key_arn   = "###ZARF_VAR_LOKI_KMS_KEY_ARN###"
 force_destroy = "###ZARF_VAR_LOKI_FORCE_DESTROY###"

--- a/aws/loki/variables.tf
+++ b/aws/loki/variables.tf
@@ -1,0 +1,18 @@
+variable "name" {
+  description = "Name for cluster"
+}
+
+variable "kms_key_arn" {
+
+}
+
+variable "key_alias" {
+  description = "alias for KMS Key"
+  default     = "bigbang-loki"
+}
+
+variable "force_destroy" {
+  description = "Option to set force destroy"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
In an attempt to resolve a random issue where zarf is not respecting the --set command that defines the cluster name