### PR TITLE
add "loki" to the name of the s3 bucket

### DIFF
--- a/aws/loki/main.tf
+++ b/aws/loki/main.tf
@@ -18,7 +18,7 @@ locals {
 
 module "S3" {
     source = "github.com/defenseunicorns/delivery-aws-iac//modules/s3-irsa"
-    name_prefix = "${var.name}"
+    name_prefix = "${var.name}-loki-"
     eks_oidc_provider_arn = local.oidc_arn
     kubernetes_service_account = "logging-loki"
     kubernetes_namespace = "logging"


### PR DESCRIPTION
Currently the name of the S3 loki bucket is the cluster name followed by timestamp (ex. `rex-eks20230517215251115700000001`)

IaC overall creates numerous S3 buckets all of which contain the cluster name followed by a specific use description:
Ex.
```
rex-gr-sessionlogs-20230517153912748900000002
rex-sessionlogs-bastion-20230502153533507800000002
rex-accesslog-ee1820230502143103389600000001
```
I think it would be helpful for `aws-dubbd` creation of the loki S3 bucket to follow the same pattern.
