### PR TITLE
Pull teardown commands into script for reuse

### DIFF
--- a/defense-unicorns-distro/scripts/teardown.sh
+++ b/defense-unicorns-distro/scripts/teardown.sh
@@ -29,9 +29,8 @@ zarf tools kubectl delete helmrelease -n bigbang kyverno --ignore-not-found
 # Cleanup validating webhoooks from kyverno
 zarf tools kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io kyverno-policy-validating-webhook-cfg kyverno-resource-validating-webhook-cfg  --ignore-not-found
 zarf tools kubectl delete helmrelease -n bigbang kiali --ignore-not-found
-# Delete metrics server if owned by Big Bang
-if zarf tools kubectl get hr metrics-server -n bigbang &>/dev/null; then
-  zarf tools kubectl delete helmrelease -n bigbang metrics-server --ignore-not-found
-  zarf tools kubectl delete apiservices.apiregistration.k8s.io v1beta1.metrics.k8s.io --ignore-not-found
-fi
+# Delete metrics server
+zarf tools kubectl delete helmrelease -n bigbang metrics-server --ignore-not-found
+# Delete metrics server api service if owned by Big Bang
+zarf tools kubectl delete apiservices.apiregistration.k8s.io -l helm.toolkit.fluxcd.io/namespace=bigbang,helm.toolkit.fluxcd.io/name=metrics-server --ignore-not-found
 zarf tools kubectl delete gitrepositories -n bigbang -l app.kubernetes.io/part-of=bigbang

--- a/defense-unicorns-distro/scripts/teardown.sh
+++ b/defense-unicorns-distro/scripts/teardown.sh
@@ -1,0 +1,34 @@
+# Suspend the BigBang Helm Release so we don't have a reconcile while cleaning up
+./zarf tools kubectl patch helmrelease -n bigbang bigbang --type=merge -p '{"spec":{"suspend":true}}'
+# Delete Istio to prevent ingress into cluster while cleanup is occuring
+./zarf tools kubectl delete helmrelease -n bigbang istio --ignore-not-found
+# Delete Istio Operator once Istio is cleaned up
+./zarf tools kubectl delete helmrelease -n bigbang istio-operator --ignore-not-found
+# Delete Monitoring
+./zarf tools kubectl delete helmrelease -n bigbang monitoring --ignore-not-found
+./zarf tools kubectl delete providers grafana -n monitoring --ignore-not-found
+./zarf tools kubectl delete alerts grafana -n monitoring --ignore-not-found
+# Delete Promtail
+./zarf tools kubectl delete helmrelease -n bigbang promtail --ignore-not-found
+# Delete Loki
+./zarf tools kubectl delete helmrelease -n bigbang loki --ignore-not-found
+# Delete Kiali
+./zarf tools kubectl delete kiali -n kiali kiali --ignore-not-found
+# Delete Tempo
+./zarf tools kubectl delete helmrelease -n bigbang tempo --ignore-not-found
+# Delete NeuVector
+./zarf tools kubectl delete helmrelease -n bigbang neuvector  --ignore-not-found
+# Cleanup NeuVector validatingwebhooks
+./zarf tools kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io neuvector-validating-crd-webhook  --ignore-not-found
+# Delete kyverno-reporter
+./zarf tools kubectl delete helmrelease -n bigbang kyverno-reporter --ignore-not-found
+# Delete kyverno-policies
+./zarf tools kubectl delete helmrelease -n bigbang kyverno-policies --ignore-not-found
+# Delete kyverno
+./zarf tools kubectl delete helmrelease -n bigbang kyverno --ignore-not-found
+# Cleanup validating webhoooks from kyverno
+./zarf tools kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io kyverno-policy-validating-webhook-cfg kyverno-resource-validating-webhook-cfg  --ignore-not-found
+./zarf tools kubectl delete helmrelease -n bigbang kiali --ignore-not-found
+./zarf tools kubectl delete helmrelease -n bigbang metrics-server --ignore-not-found
+./zarf tools kubectl delete gitrepositories -n bigbang -l app.kubernetes.io/part-of=bigbang
+./zarf tools kubectl delete apiservices.apiregistration.k8s.io v1beta1.metrics.k8s.io --ignore-not-found

--- a/defense-unicorns-distro/scripts/teardown.sh
+++ b/defense-unicorns-distro/scripts/teardown.sh
@@ -1,37 +1,37 @@
 # Suspend the BigBang Helm Release so we don't have a reconcile while cleaning up
-./zarf tools kubectl patch helmrelease -n bigbang bigbang --type=merge -p '{"spec":{"suspend":true}}'
+zarf tools kubectl patch helmrelease -n bigbang bigbang --type=merge -p '{"spec":{"suspend":true}}'
 # Delete Istio to prevent ingress into cluster while cleanup is occuring
-./zarf tools kubectl delete helmrelease -n bigbang istio --ignore-not-found
+zarf tools kubectl delete helmrelease -n bigbang istio --ignore-not-found
 # Delete Istio Operator once Istio is cleaned up
-./zarf tools kubectl delete helmrelease -n bigbang istio-operator --ignore-not-found
+zarf tools kubectl delete helmrelease -n bigbang istio-operator --ignore-not-found
 # Delete Monitoring
-./zarf tools kubectl delete helmrelease -n bigbang monitoring --ignore-not-found
-./zarf tools kubectl delete providers grafana -n monitoring --ignore-not-found
-./zarf tools kubectl delete alerts grafana -n monitoring --ignore-not-found
+zarf tools kubectl delete helmrelease -n bigbang monitoring --ignore-not-found
+zarf tools kubectl delete providers grafana -n monitoring --ignore-not-found
+zarf tools kubectl delete alerts grafana -n monitoring --ignore-not-found
 # Delete Promtail
-./zarf tools kubectl delete helmrelease -n bigbang promtail --ignore-not-found
+zarf tools kubectl delete helmrelease -n bigbang promtail --ignore-not-found
 # Delete Loki
-./zarf tools kubectl delete helmrelease -n bigbang loki --ignore-not-found
+zarf tools kubectl delete helmrelease -n bigbang loki --ignore-not-found
 # Delete Kiali
-./zarf tools kubectl delete kiali -n kiali kiali --ignore-not-found
+zarf tools kubectl delete kiali -n kiali kiali --ignore-not-found
 # Delete Tempo
-./zarf tools kubectl delete helmrelease -n bigbang tempo --ignore-not-found
+zarf tools kubectl delete helmrelease -n bigbang tempo --ignore-not-found
 # Delete NeuVector
-./zarf tools kubectl delete helmrelease -n bigbang neuvector  --ignore-not-found
+zarf tools kubectl delete helmrelease -n bigbang neuvector  --ignore-not-found
 # Cleanup NeuVector validatingwebhooks
-./zarf tools kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io neuvector-validating-crd-webhook  --ignore-not-found
+zarf tools kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io neuvector-validating-crd-webhook  --ignore-not-found
 # Delete kyverno-reporter
-./zarf tools kubectl delete helmrelease -n bigbang kyverno-reporter --ignore-not-found
+zarf tools kubectl delete helmrelease -n bigbang kyverno-reporter --ignore-not-found
 # Delete kyverno-policies
-./zarf tools kubectl delete helmrelease -n bigbang kyverno-policies --ignore-not-found
+zarf tools kubectl delete helmrelease -n bigbang kyverno-policies --ignore-not-found
 # Delete kyverno
-./zarf tools kubectl delete helmrelease -n bigbang kyverno --ignore-not-found
+zarf tools kubectl delete helmrelease -n bigbang kyverno --ignore-not-found
 # Cleanup validating webhoooks from kyverno
-./zarf tools kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io kyverno-policy-validating-webhook-cfg kyverno-resource-validating-webhook-cfg  --ignore-not-found
-./zarf tools kubectl delete helmrelease -n bigbang kiali --ignore-not-found
+zarf tools kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io kyverno-policy-validating-webhook-cfg kyverno-resource-validating-webhook-cfg  --ignore-not-found
+zarf tools kubectl delete helmrelease -n bigbang kiali --ignore-not-found
 # Delete metrics server if owned by Big Bang
-if ./zarf tools kubectl get hr metrics-server -n bigbang &>/dev/null; then
-  ./zarf tools kubectl delete helmrelease -n bigbang metrics-server --ignore-not-found
-  ./zarf tools kubectl delete apiservices.apiregistration.k8s.io v1beta1.metrics.k8s.io --ignore-not-found
+if zarf tools kubectl get hr metrics-server -n bigbang &>/dev/null; then
+  zarf tools kubectl delete helmrelease -n bigbang metrics-server --ignore-not-found
+  zarf tools kubectl delete apiservices.apiregistration.k8s.io v1beta1.metrics.k8s.io --ignore-not-found
 fi
-./zarf tools kubectl delete gitrepositories -n bigbang -l app.kubernetes.io/part-of=bigbang
+zarf tools kubectl delete gitrepositories -n bigbang -l app.kubernetes.io/part-of=bigbang

--- a/defense-unicorns-distro/scripts/teardown.sh
+++ b/defense-unicorns-distro/scripts/teardown.sh
@@ -29,6 +29,9 @@
 # Cleanup validating webhoooks from kyverno
 ./zarf tools kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io kyverno-policy-validating-webhook-cfg kyverno-resource-validating-webhook-cfg  --ignore-not-found
 ./zarf tools kubectl delete helmrelease -n bigbang kiali --ignore-not-found
-./zarf tools kubectl delete helmrelease -n bigbang metrics-server --ignore-not-found
+# Delete metrics server if owned by Big Bang
+if ./zarf tools kubectl get hr metrics-server -n bigbang &>/dev/null; then
+  ./zarf tools kubectl delete helmrelease -n bigbang metrics-server --ignore-not-found
+  ./zarf tools kubectl delete apiservices.apiregistration.k8s.io v1beta1.metrics.k8s.io --ignore-not-found
+fi
 ./zarf tools kubectl delete gitrepositories -n bigbang -l app.kubernetes.io/part-of=bigbang
-./zarf tools kubectl delete apiservices.apiregistration.k8s.io v1beta1.metrics.k8s.io --ignore-not-found

--- a/defense-unicorns-distro/zarf.yaml
+++ b/defense-unicorns-distro/zarf.yaml
@@ -105,7 +105,7 @@ components:
           - cmd: |
               export PATH=$(dirname ./zarf):$PATH
               ./teardown.sh
-            description: "tearing down Big Bang"
+            description: "Tear down Big Bang"
     files:
       - source: scripts/teardown.sh
         target: teardown.sh

--- a/defense-unicorns-distro/zarf.yaml
+++ b/defense-unicorns-distro/zarf.yaml
@@ -102,7 +102,10 @@ components:
             description: "Patch BigBang to force an update on updates"
       onRemove:
         before:
-          - cmd: "./teardown.sh"
+          - cmd: |
+              export PATH=$(dirname ./zarf):$PATH
+              ./teardown.sh
+            description: "tearing down Big Bang"
     files:
       - source: scripts/teardown.sh
         target: teardown.sh

--- a/defense-unicorns-distro/zarf.yaml
+++ b/defense-unicorns-distro/zarf.yaml
@@ -102,42 +102,11 @@ components:
             description: "Patch BigBang to force an update on updates"
       onRemove:
         before:
-          - cmd: ./zarf tools kubectl patch helmrelease -n bigbang bigbang --type=merge -p '{"spec":{"suspend":true}}'
-            description: Suspend the BigBang Helm Release so we don't have a reconcile while cleaning up
-          - cmd: ./zarf tools kubectl delete helmrelease -n bigbang istio --ignore-not-found
-            description: Delete istio to prevent ingress into cluster while cleanup is occuring
-          - cmd: ./zarf tools kubectl delete helmrelease -n bigbang istio-operator --ignore-not-found
-            description: Delete istio-operator once istio is cleaned up
-          - cmd: ./zarf tools kubectl delete helmrelease -n bigbang monitoring --ignore-not-found
-            description: Delete Monitoring
-          - cmd: ./zarf tools kubectl delete providers grafana -n monitoring --ignore-not-found
-          - cmd: ./zarf tools kubectl delete alerts grafana -n monitoring --ignore-not-found
-          - cmd: ./zarf tools kubectl delete helmrelease -n bigbang promtail --ignore-not-found
-            description: Delete promtail
-          - cmd: ./zarf tools kubectl delete helmrelease -n bigbang loki --ignore-not-found
-            description: Delete loki
-          - cmd: ./zarf tools kubectl delete kiali -n kiali kiali --ignore-not-found
-            description: Delete Kiali
-          - cmd: ./zarf tools kubectl delete helmrelease -n bigbang tempo --ignore-not-found
-            description: Delete Tempo
-          - cmd: ./zarf tools kubectl delete helmrelease -n bigbang neuvector  --ignore-not-found
-            description: Delete neuvector
-          - cmd: ./zarf tools kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io neuvector-validating-crd-webhook  --ignore-not-found
-            description: cleanup neuvector validatingwebhooks
-          - cmd: ./zarf tools kubectl delete helmrelease -n bigbang kyverno-reporter --ignore-not-found
-            description: Delete kyverno-reporter
-          - cmd: ./zarf tools kubectl delete helmrelease -n bigbang kyverno-policies --ignore-not-found
-            description: Delete kyverno-policies
-          - cmd: ./zarf tools kubectl delete helmrelease -n bigbang kyverno --ignore-not-found
-            description: Delete kyverno
-          - cmd: ./zarf tools kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io neuvector-validating-crd-webhook  --ignore-not-found
-            description: cleanup neuvector validatingwebhooks
-          - cmd: ./zarf tools kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io kyverno-policy-validating-webhook-cfg kyverno-resource-validating-webhook-cfg  --ignore-not-found
-            description: Cleanup validating webhoooks from kyverno
-          - cmd: ./zarf tools kubectl delete helmrelease -n bigbang kiali --ignore-not-found
-          - cmd: ./zarf tools kubectl delete helmrelease -n bigbang metrics-server --ignore-not-found
-          - cmd: ./zarf tools kubectl delete gitrepositories -n bigbang -l app.kubernetes.io/part-of=bigbang
-          - cmd: ./zarf tools kubectl delete apiservices.apiregistration.k8s.io v1beta1.metrics.k8s.io --ignore-not-found
+          - cmd: "./teardown.sh"
+    files:
+      - source: scripts/teardown.sh
+        target: teardown.sh
+        executable: true
     manifests:
       - name: slack-alerts
         files:


### PR DESCRIPTION
Teardown commands will likely be reused for `onFailure` on an install, so pulling them out to a separate script file for better future reuse.

Also fixes a bug with the metrics-server deletion step, ensuring it is owned by BB before removing.