### PR TITLE
fix: update aws zarf loki-module component tf path

### DIFF
--- a/aws/zarf.yaml
+++ b/aws/zarf.yaml
@@ -66,10 +66,10 @@ components:
     actions:
       onCreate:
         before:
-          - cmd: "terraform init -upgrade"
+          - cmd: "../run/loki/terraform init -upgrade"
             dir: loki
         after:
-          - cmd: "test -d ./run/ && chmod -R ugo+rwx ./run/ || echo $?"
+          - cmd: "test -d ../run/ && chmod -R ugo+rwx ../run/ || echo $?"
     files:
     # terraform code
     - source: loki/.terraform


### PR DESCRIPTION
in the current state, if the machine running zarf package does not have the terraform cli installed, it fails.
fixing the path where it is referencing the terraform stuff for the zarf loki module component.