### PR TITLE
Help Zarf catch upgrade failures

### DIFF
--- a/aws/zarf-config.yaml
+++ b/aws/zarf-config.yaml
@@ -4,6 +4,8 @@ package:
     set:
       # renovate: datasource=gitlab-tags depName=big-bang/bigbang versioning=semver registryUrl=https://repo1.dso.mil
       bigbang_version: "2.1.0"
+      # should line up with the flux version in the BB release, see https://repo1.dso.mil/big-bang/bigbang/-/blob/master/base/flux/gotk-components.yaml#L3
+      flux_version: "0.41.2"
       terraform_version: "1.4.2"
       terraform_provider_aws_version: 4.59.0
   deploy:

--- a/aws/zarf.yaml
+++ b/aws/zarf.yaml
@@ -111,6 +111,14 @@ components:
     required: true
     import:
       path: ../defense-unicorns-distro
+  - name: preflight
+    required: true
+    import:
+      path: ../defense-unicorns-distro
+  - name: download-flux
+    required: true
+    import:
+      path: ../defense-unicorns-distro
   - name: bigbang
     required: true
     import:

--- a/cocowow/zarf-config.yaml
+++ b/cocowow/zarf-config.yaml
@@ -4,6 +4,8 @@ package:
     set:
       # renovate: datasource=gitlab-tags depName=big-bang/bigbang versioning=semver registryUrl=https://repo1.dso.mil
       bigbang_version: "2.1.0"
+      # should line up with the flux version in the BB release, see https://repo1.dso.mil/big-bang/bigbang/-/blob/master/base/flux/gotk-components.yaml#L3
+      flux_version: "0.41.2"
   deploy:
     set:
       keycloak_key_file: bigbang.dev.key

--- a/cocowow/zarf.yaml
+++ b/cocowow/zarf.yaml
@@ -61,6 +61,10 @@ components:
         - cmd: ./cat_keycloak_key.sh
           description: read the cert
           setVariable: KEYCLOAK_KEY
+  - name: download-flux
+    required: true
+    import:
+      path: ../defense-unicorns-distro
   - name: cocowow
     required: true
     import:

--- a/defense-unicorns-distro/scripts/extract_flux.sh
+++ b/defense-unicorns-distro/scripts/extract_flux.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Check if the runtime environment is Darwin (Mac OS X), Linux, or Windows
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  ARCH_NAME=darwin
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  ARCH_NAME=linux
+elif [[ "$OSTYPE" == "msys" ]]; then
+  ARCH_NAME=windows
+elif [[ "$OSTYPE" == "cygwin" ]]; then
+  ARCH_NAME=windows
+else
+  echo "The OS is not supported"
+  exit 1
+fi
+
+# Check the processor architecture
+if [[ $(uname -m) == "x86_64" ]]; then
+  ARCH_PROC=amd64
+elif [[ $(uname -m) == "i686" || $(uname -m) == "i386" ]]; then
+  echo "The processor architecture is 32-bit and not supported"
+  exit 1
+elif [[ $(uname -m) == "arm64" ]]; then
+  ARCH_PROC=arm64
+else
+  # Default to amd64
+  ARCH_PROC=amd64
+fi
+
+# Extract the correct Flux binary
+mkdir -p run/flux
+if [[ $ARCH_NAME == "windows" ]]; then
+  # Windows Flux artifacts are zip files
+  unzip -o -q tmp/flux_${1}_${ARCH_NAME}_${ARCH_PROC}.zip -d run/flux
+else
+  tar -zxf tmp/flux_${1}_${ARCH_NAME}_${ARCH_PROC}.tar.gz -C run/flux
+fi

--- a/defense-unicorns-distro/scripts/on_failure.sh
+++ b/defense-unicorns-distro/scripts/on_failure.sh
@@ -6,9 +6,9 @@ else
 fi
 
 # This will grab any helmreleases with a failed condition
-state=$(kubectl get helmrelease -n bigbang -o go-template='{{range $items,$contents := .items}}{{printf "HR %s" $contents.metadata.name}}{{printf " status is %s\n" (index $contents.status.conditions 0).reason}}{{end}}')
+state=$(zarf tools kubectl get helmrelease -n bigbang -o go-template='{{range $items,$contents := .items}}{{printf "HR %s" $contents.metadata.name}}{{printf " status is %s\n" (index $contents.status.conditions 0).reason}}{{end}}')
 failed=$(echo "${state}" | grep "Failed")
 failed_hrs=$(echo "{$failed}" | awk  '{print $2}')
 for hr in $failed_hrs; do
-    kubectl describe helmrelease -n bigbang $hr
+    zarf tools kubectl describe helmrelease -n bigbang $hr
 done

--- a/defense-unicorns-distro/scripts/on_failure.sh
+++ b/defense-unicorns-distro/scripts/on_failure.sh
@@ -1,0 +1,14 @@
+# Placeholder for rollback tasks
+if [ "###ZARF_VAR_IS_UPGRADE###" = "true" ]; then
+    echo "Failed upgrade"
+else
+    echo "Failed install"
+fi
+
+# This will grab any helmreleases with a failed condition
+state=$(kubectl get helmrelease -n bigbang -o go-template='{{range $items,$contents := .items}}{{printf "HR %s" $contents.metadata.name}}{{printf " status is %s\n" (index $contents.status.conditions 0).reason}}{{end}}')
+failed=$(echo "${state}" | grep "Failed")
+failed_hrs=$(echo "{$failed}" | awk  '{print $2}')
+for hr in $failed_hrs; do
+    kubectl describe helmrelease -n bigbang $hr
+done

--- a/defense-unicorns-distro/scripts/reconcile_helmreleases.sh
+++ b/defense-unicorns-distro/scripts/reconcile_helmreleases.sh
@@ -1,0 +1,3 @@
+for package in kyverno kyverno-policies istio-operator istio monitoring loki metrics-server tempo promtail neuvector kiali kyverno-reporter; do
+    zarf tools kubectl patch helmrelease -n bigbang $package --type=merge -p '{"metadata":{"annotations":{"reconcile.fluxcd.io/requestedAt":"'`date '+%F_%H:%M:%S.%s%z'`'"}}}' || true
+done

--- a/defense-unicorns-distro/zarf-config.yaml
+++ b/defense-unicorns-distro/zarf-config.yaml
@@ -4,6 +4,8 @@ package:
     set:
       # renovate: datasource=gitlab-tags depName=big-bang/bigbang versioning=semver registryUrl=https://repo1.dso.mil
       bigbang_version: "2.1.0"
+      # should line up with the flux version in the BB release, see https://repo1.dso.mil/big-bang/bigbang/-/blob/master/base/flux/gotk-components.yaml#L3
+      flux_version: "0.41.2"
   deploy:
     set:
       domain: bigbang.dev

--- a/defense-unicorns-distro/zarf.yaml
+++ b/defense-unicorns-distro/zarf.yaml
@@ -10,6 +10,7 @@ metadata:
 
 variables:
 - name: BIGBANG_VERSION
+- name: FLUX_VERSION
 - name: DOMAIN
   default: bigbang.dev
   prompt: false
@@ -88,22 +89,68 @@ components:
         - cmd: "./zarf tools kubectl version --short || true"
           setVariables:
             - name: OUTPUT
-        - cmd: "./zarf tools kubectl get helmrelease bigbang -n bigbang &>/dev/null && echo true || echo false"
-          setVariables:
-            - name: IS_UPGRADE
         after:
-        - cmd: "./preflight.sh"
+        - cmd: ./preflight.sh
+        - cmd: rm preflight.sh
     files:
     - source: scripts/preflight.sh
       target: preflight.sh
       executable: true
-  - name: bigbang
+  - name: download-flux
     required: true
     actions:
       onDeploy:
         after:
-          - cmd: ./zarf tools kubectl patch helmrelease -n bigbang bigbang --type=merge -p '{"metadata":{"annotations":{"reconcile.fluxcd.io/requestedAt":"'`date '+%F_%H:%M:%S.%s%z'`'"}}}'
-            description: "Patch BigBang to force an update on updates"
+          - cmd: rm -f run/flux/flux || true
+            description: Clean up previous flux install
+          - cmd: "./extract_flux.sh ###ZARF_PKG_TMPL_FLUX_VERSION###"
+            description: Extract flux binary
+          - cmd: "rm extract_flux.sh && rm -f tmp/flux*"
+            description: Clean up extra flux artifacts
+    files:
+      - source: scripts/extract_flux.sh
+        target: extract_flux.sh
+        executable: true
+      - source: https://github.com/fluxcd/flux2/releases/download/v###ZARF_PKG_TMPL_FLUX_VERSION###/flux_###ZARF_PKG_TMPL_FLUX_VERSION###_darwin_arm64.tar.gz
+        target: tmp/flux_###ZARF_PKG_TMPL_FLUX_VERSION###_darwin_arm64.tar.gz
+      - source: https://github.com/fluxcd/flux2/releases/download/v###ZARF_PKG_TMPL_FLUX_VERSION###/flux_###ZARF_PKG_TMPL_FLUX_VERSION###_darwin_amd64.tar.gz
+        target: tmp/flux_###ZARF_PKG_TMPL_FLUX_VERSION###_darwin_amd64.tar.gz
+      - source: https://github.com/fluxcd/flux2/releases/download/v###ZARF_PKG_TMPL_FLUX_VERSION###/flux_###ZARF_PKG_TMPL_FLUX_VERSION###_linux_amd64.tar.gz
+        target: tmp/flux_###ZARF_PKG_TMPL_FLUX_VERSION###_linux_amd64.tar.gz
+      - source: https://github.com/fluxcd/flux2/releases/download/v###ZARF_PKG_TMPL_FLUX_VERSION###/flux_###ZARF_PKG_TMPL_FLUX_VERSION###_linux_arm64.tar.gz
+        target: tmp/flux_###ZARF_PKG_TMPL_FLUX_VERSION###_linux_arm64.tar.gz
+      - source: https://github.com/fluxcd/flux2/releases/download/v###ZARF_PKG_TMPL_FLUX_VERSION###/flux_###ZARF_PKG_TMPL_FLUX_VERSION###_windows_amd64.zip
+        target: tmp/flux_###ZARF_PKG_TMPL_FLUX_VERSION###_windows_amd64.zip
+      - source: https://github.com/fluxcd/flux2/releases/download/v###ZARF_PKG_TMPL_FLUX_VERSION###/flux_###ZARF_PKG_TMPL_FLUX_VERSION###_windows_arm64.zip
+        target: tmp/flux_###ZARF_PKG_TMPL_FLUX_VERSION###_windows_arm64.zip
+  - name: bigbang
+    required: true
+    actions:
+      onDeploy:
+        before:
+        - cmd: "./zarf tools kubectl get helmrelease bigbang -n bigbang >/dev/null 2>&1 && echo true || echo false"
+          mute: true
+          description: "Detect if this is an upgrade"
+          setVariables:
+            - name: IS_UPGRADE
+        after:
+          - cmd: ./zarf tools kubectl wait --for=jsonpath='{.spec.ref.tag}'=###ZARF_PKG_TMPL_BIGBANG_VERSION### gitrepository bigbang -n bigbang --timeout=5m
+            description: "Wait for BigBang GitRepository to update to latest version"
+            mute: true
+          - cmd: ./flux reconcile helmrelease bigbang -n bigbang --with-source
+            dir: run/flux
+            description: "Reconcile Big Bang helmrelease with source"
+            maxTotalSeconds: 600
+          - cmd: |
+              export PATH=$(dirname ./zarf):$PATH
+              ./reconcile_helmreleases.sh
+            mute: true
+            description: "Patch package helmreleases to force reconciliation on upgrade"
+        onFailure:
+          - cmd: |
+              export PATH=$(dirname ./zarf):$PATH
+              ./on_failure.sh
+            description: "Print debug for failed deployment"
       onRemove:
         before:
           - cmd: |
@@ -111,6 +158,12 @@ components:
               ./teardown.sh
             description: "Tear down Big Bang"
     files:
+      - source: scripts/reconcile_helmreleases.sh
+        target: reconcile_helmreleases.sh
+        executable: true
+      - source: scripts/on_failure.sh
+        target: on_failure.sh
+        executable: true
       - source: scripts/teardown.sh
         target: teardown.sh
         executable: true

--- a/k3d/zarf-config.yaml
+++ b/k3d/zarf-config.yaml
@@ -4,6 +4,8 @@ package:
     set:
       # renovate: datasource=gitlab-tags depName=big-bang/bigbang versioning=semver registryUrl=https://repo1.dso.mil
       bigbang_version: "2.1.0"
+      # should line up with the flux version in the BB release, see https://repo1.dso.mil/big-bang/bigbang/-/blob/master/base/flux/gotk-components.yaml#L3
+      flux_version: "0.41.2"
   deploy:
     set:
       domain: bigbang.dev

--- a/k3d/zarf.yaml
+++ b/k3d/zarf.yaml
@@ -23,6 +23,14 @@ components:
     required: true
     import:
       path: ../defense-unicorns-distro
+  - name: preflight
+    required: true
+    import:
+      path: ../defense-unicorns-distro
+  - name: download-flux
+    required: true
+    import:
+      path: ../defense-unicorns-distro
   - name: bigbang
     required: true
     import:


### PR DESCRIPTION
The primary goal of this PR is to have Zarf catch failures of a DUBBD install/upgrade. This is accomplished by altering the `onDeploy.after` actions to add:
- wait on the `bigbang` gitrepository to have the correct BB version
- flux reconciliation of `bigbang` helmrelease (with source)
- kubectl patches to force reconciliation of all BB packages

Secondary addition was to add an `onFailure` action with additional debug (kubectl describe) *if* a helmrelease shows as being in a failed state. If no helmrelease shows as failed the debug log will still contain all helmrelease describes (baked into zarf extension).