### PR TITLE
Cleanup values, mTLS STRICT for kiali/promtail

### DIFF
--- a/aws/values/aws-loki.yaml
+++ b/aws/values/aws-loki.yaml
@@ -1,5 +1,5 @@
 loki:
-  strategy: "scalable" # i think?
+  strategy: "scalable"
   objectStorage:
     endpoint: https://s3.amazonaws.com
     region: "###ZARF_VAR_LOKI_S3_AWS_REGION###"

--- a/defense-unicorns-distro/zarf.yaml
+++ b/defense-unicorns-distro/zarf.yaml
@@ -4,7 +4,7 @@ metadata:
   description: "Defense Unicorns Big Bang Distro"
   version: "###ZARF_PKG_TMPL_BIGBANG_VERSION###"
   url: https://p1.dso.mil/products/big-bang
-  image: https://p1.dso.mil/img/Big_Bang_Color_Logo_White_text.de14c793.webp
+  image: https://p1.dso.mil/Big_Bang_Color_Logo_White_text.b10a1bae.webp
   # Big Bang / Iron Bank are only amd64
   architecture: amd64
 

--- a/values/kiali.yaml
+++ b/values/kiali.yaml
@@ -2,9 +2,6 @@
 kiali:
   enabled: true
   values:
-    istio:
-      mtls:
-        mode: PERMISSIVE
     resources:
       requests:
         cpu: "100m"

--- a/values/loki.yaml
+++ b/values/loki.yaml
@@ -1,4 +1,3 @@
-
 loki:
   strategy: "monolith"
   values:

--- a/values/promtail.yaml
+++ b/values/promtail.yaml
@@ -2,9 +2,6 @@
 promtail:
   enabled: true
   values:
-    istio:
-      mtls:
-        mode: PERMISSIVE
     resources:
       limits:
         cpu: "500m"

--- a/values/values.yaml
+++ b/values/values.yaml
@@ -6,18 +6,6 @@ networkPolicies:
   nodeCidr: "0.0.0.0/0"
   vpcCidr: "0.0.0.0/0"
 
-elasticsearchKibana:
-  enabled: false
-
-eckOperator:
-  enabled: false
-
-fluentbit:
-  enabled: false
-
-twistlock:
-  enabled: false
-
 addons:
   velero:
     enabled: false


### PR DESCRIPTION
Couple cleanup pieces:
- random comment
- random newline
- EFK + twistlock disable values (not needed post-2.0)
- logo/image link fix

Functional changes: Removed mTLS permissive override for kiali/promtail. This appears to work fine and has been set as the default in BB for a while now - I believe it was a legacy carryover that isn't necessary in current BB/DUBBD versions.