### PR TITLE
adds zarf directory artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .DS_Store
 defense-unicorns-distro/preflight.sh
 .terraform
+tmp
+zarf-sbom


### PR DESCRIPTION
Failed Zarf commands leave behind directories, this PR adds them to the `.gitignore`